### PR TITLE
Save more dataset metadata with trained model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="1.2.3",
+    version="1.3.0",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/cli_utils/model_utils.py
+++ b/tf2_gnn/cli_utils/model_utils.py
@@ -23,6 +23,8 @@ def save_model(save_file: str, model: GraphTaskModel, dataset: GraphDataset) -> 
         "dataset_class": dataset.__class__,
         "dataset_params": dataset._params,
         "dataset_metadata": dataset._metadata,
+        "num_edge_types": dataset.num_edge_types,
+        "node_feature_shape": dataset.node_feature_shape,
     }
     pkl_file = get_model_file_path(save_file, "pkl")
     hdf5_file = get_model_file_path(save_file, "hdf5")


### PR DESCRIPTION
This is required to allow loading a trained model without a matching dataset, which we need in some downstream applications.