### PR TITLE
Fix name scopes to avoid unique counters which keep changing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="1.3.0",
+    version="2.0.0",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/cli_utils/model_utils.py
+++ b/tf2_gnn/cli_utils/model_utils.py
@@ -34,7 +34,12 @@ def save_model(save_file: str, model: GraphTaskModel, dataset: GraphDataset) -> 
     print(f"   (Stored model metadata to {pkl_file} and weights to {hdf5_file})")
 
 
-def load_weights_verbosely(save_file: str, model: GraphTaskModel):
+def load_weights_verbosely(
+    save_file: str,
+    model: GraphTaskModel,
+    warn_about_initialisations: bool = True,
+    warn_about_ignored: bool = True,
+):
     hdf5_save_file = get_model_file_path(save_file, "hdf5")
     var_name_to_variable = {}
     var_names_unique = True
@@ -72,13 +77,15 @@ def load_weights_verbosely(save_file: str, model: GraphTaskModel):
     for var_name, tfvar in var_name_to_variable.items():
         saved_weight = var_name_to_weights.get(var_name)
         if saved_weight is None:
-            print(f"I: Weights for {var_name} freshly initialised.")
+            if warn_about_initialisations:
+                print(f"I: Weights for {var_name} freshly initialised.")
         else:
             tfvar_weight_tuples.append((tfvar, saved_weight))
 
-    for var_name in var_name_to_weights.keys():
-        if var_name not in var_name_to_variable:
-            print(f"I: Model does not use saved weights for {var_name}.")
+    if warn_about_ignored:
+        for var_name in var_name_to_weights.keys():
+            if var_name not in var_name_to_variable:
+                print(f"I: Model does not use saved weights for {var_name}.")
 
     K.batch_set_value(tfvar_weight_tuples)
 

--- a/tf2_gnn/layers/graph_global_exchange.py
+++ b/tf2_gnn/layers/graph_global_exchange.py
@@ -116,7 +116,7 @@ class GraphGlobalMeanExchange(GraphGlobalExchange):
         super().__init__(hidden_dim, weighting_fun, num_heads, dropout_rate)
 
     def build(self, tensor_shapes: GraphGlobalExchangeInput):
-        with tf.name_scope(self._name):
+        with tf.name_scope(self.__class__.__name__):
             super().build(tensor_shapes)
 
     def call(self, inputs: GraphGlobalExchangeInput, training: bool = False):
@@ -138,7 +138,7 @@ class GraphGlobalGRUExchange(GraphGlobalExchange):
         super().__init__(hidden_dim, weighting_fun, num_heads, dropout_rate)
 
     def build(self, tensor_shapes: GraphGlobalExchangeInput):
-        with tf.name_scope(self._name):
+        with tf.name_scope(self.__class__.__name__):
             self._gru_cell = tf.keras.layers.GRUCell(units=self._hidden_dim)
             self._gru_cell.build(tf.TensorShape((None, self._hidden_dim)))
             super().build(tensor_shapes)
@@ -167,7 +167,7 @@ class GraphGlobalMLPExchange(GraphGlobalExchange):
         super().__init__(hidden_dim, weighting_fun, num_heads, dropout_rate)
 
     def build(self, tensor_shapes: GraphGlobalExchangeInput):
-        with tf.name_scope(self._name):
+        with tf.name_scope(self.__class__.__name__):
             self._mlp = MLP(out_size=self._hidden_dim)
             self._mlp.build(tf.TensorShape((None, 2 * self._hidden_dim)))
             super().build(tensor_shapes)

--- a/tf2_gnn/layers/message_passing/gnn_film.py
+++ b/tf2_gnn/layers/message_passing/gnn_film.py
@@ -69,15 +69,14 @@ class GNN_FiLM(GNN_Edge_MLP):
         adjacency_list_shapes = input_shapes.adjacency_lists
         num_edge_types = len(adjacency_list_shapes)
 
-        with tf.name_scope(self._name):
-            for i in range(num_edge_types):
-                with tf.name_scope(f"edge_type_{i}-FiLM"):
-                    film_mlp = MLP(
-                        out_size=2 * self._hidden_dim,
-                        hidden_layers=self._film_parameter_MLP_hidden_layers,
-                    )
-                    film_mlp.build(tf.TensorShape((None, node_embedding_shapes[-1])))
-                    self._edge_type_film_layer_computations.append(film_mlp)
+        for i in range(num_edge_types):
+            with tf.name_scope(f"edge_type_{i}-FiLM"):
+                film_mlp = MLP(
+                    out_size=2 * self._hidden_dim,
+                    hidden_layers=self._film_parameter_MLP_hidden_layers,
+                )
+                film_mlp.build(tf.TensorShape((None, node_embedding_shapes[-1])))
+                self._edge_type_film_layer_computations.append(film_mlp)
 
         super().build(input_shapes)
 

--- a/tf2_gnn/layers/message_passing/rgin.py
+++ b/tf2_gnn/layers/message_passing/rgin.py
@@ -76,14 +76,13 @@ class RGIN(GNN_Edge_MLP):
 
     def build(self, input_shapes: MessagePassingInput):
         node_embedding_shapes = input_shapes.node_embeddings
-        with tf.name_scope(self._name):
-            if self._num_aggr_MLP_hidden_layers is not None:
-                with tf.name_scope("aggregation_MLP"):
-                    self._aggregation_mlp = MLP(
-                        out_size=self._hidden_dim,
-                        hidden_layers=[self._hidden_dim] * self._num_aggr_MLP_hidden_layers,
-                    )
-                    self._aggregation_mlp.build(tf.TensorShape((None, self._hidden_dim)))
+        if self._num_aggr_MLP_hidden_layers is not None:
+            with tf.name_scope("aggregation_MLP"):
+                self._aggregation_mlp = MLP(
+                    out_size=self._hidden_dim,
+                    hidden_layers=[self._hidden_dim] * self._num_aggr_MLP_hidden_layers,
+                )
+                self._aggregation_mlp.build(tf.TensorShape((None, self._hidden_dim)))
         super().build(input_shapes)
 
     def _compute_new_node_embeddings(

--- a/tf2_gnn/models/graph_binary_classification_task.py
+++ b/tf2_gnn/models/graph_binary_classification_task.py
@@ -26,7 +26,7 @@ class GraphBinaryClassificationTask(GraphTaskModel):
         self._node_to_graph_aggregation = None
 
     def build(self, input_shapes):
-        with tf.name_scope(self._name):
+        with tf.name_scope(self.__class__.__name__):
             self._node_to_graph_repr_layer = WeightedSumGraphRepresentation(
                 graph_representation_size=self._params["graph_aggregation_num_heads"],
                 num_heads=self._params["graph_aggregation_num_heads"],

--- a/tf2_gnn/models/graph_regression_task.py
+++ b/tf2_gnn/models/graph_regression_task.py
@@ -27,7 +27,7 @@ class GraphRegressionTask(GraphTaskModel):
         self._node_to_graph_aggregation = None
 
     def build(self, input_shapes):
-        with tf.name_scope(self._name):
+        with tf.name_scope(self.__class__.__name__):
             self._node_to_graph_repr_layer = WeightedSumGraphRepresentation(
                 graph_representation_size=self._params["graph_aggregation_num_heads"],
                 num_heads=self._params["graph_aggregation_num_heads"],

--- a/tf2_gnn/models/node_multiclass_task.py
+++ b/tf2_gnn/models/node_multiclass_task.py
@@ -38,7 +38,7 @@ class NodeMulticlassTask(GraphTaskModel):
         self._num_labels = dataset.num_node_target_labels
 
     def build(self, input_shapes):
-        with tf.name_scope(self._name):
+        with tf.name_scope(self.__class__.__name__):
             self.node_to_labels_layer = tf.keras.layers.Dense(units=self._num_labels, use_bias=True)
             self.node_to_labels_layer.build((None, self._params["gnn_hidden_dim"]))
         super().build(input_shapes)


### PR DESCRIPTION
This keeps breaking loading of model weights by name, which we need for scenarios in which we change the model layout.

The downside of this PR is that it breaks existing models (as in they can't be loaded anymore) - should this trigger a major version number bump?