### PR TITLE
Extend dataset tests to check self loops and backward edges

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.2.0",
+    version="2.2.1",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/test/data/test_datasets.py
+++ b/tf2_gnn/test/data/test_datasets.py
@@ -98,6 +98,8 @@ def ppi_train_valid_paths(tmp_data_dir):
 @pytest.fixture
 def jsonl_test_case():
     dataset_params = JsonLGraphPropertyDataset.get_default_hyperparameters()
+    dataset_params["num_fwd_edge_types"] = 4
+
     dataset = JsonLGraphPropertyDataset(dataset_params)
     data_path = RichPath.create(os.path.join(os.path.dirname(__file__), "..", "test_datasets"))
     dataset.load_data(data_path, folds_to_load={DataFold.TRAIN, DataFold.VALIDATION})
@@ -105,7 +107,7 @@ def jsonl_test_case():
     return TestCase(
         dataset=dataset,
         expected=TestExpectedValues(
-            num_edge_types=4,
+            num_edge_types=dataset_params["num_fwd_edge_types"] + 1,
             node_feature_shape=(35,),
             num_train_samples=10,
             num_valid_samples=10,


### PR DESCRIPTION
- Extended `test_datasets.py` to check that self loops and backward edges are added correctly.
- The data in `test/test_datasets` was not consistent with the test, since it _implied_ there are 4 edge types (i.e. adjacency lists have shape `[[], [], [], []]`). The test was passing anyway, because the fourth list in the data from `test/test_datasets` is always empty, and the data loading code is written in a way that ignores this discrepancy. The fact that the number of edge types is implied by several things and they can imply different values is a deeper problem, but for now I changed the values in the test to reflect the state of `test/test_datasets` files.