### PR TITLE
Unify processing of adjacency lists across datasets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.2.1",
+    version="2.2.2",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/data/jsonl_graph_dataset.py
+++ b/tf2_gnn/data/jsonl_graph_dataset.py
@@ -6,6 +6,7 @@ import numpy as np
 from dpu_utils.utils import RichPath
 
 from .graph_dataset import DataFold, GraphDataset, GraphSampleType, GraphSample
+from .utils import process_adjacency_lists
 
 logger = logging.getLogger(__name__)
 
@@ -123,51 +124,14 @@ class JsonLGraphDataset(GraphDataset[GraphSampleType]):
 
     def _process_raw_adjacency_lists(
         self, raw_adjacency_lists: List[List[Tuple]], num_nodes: int
-    ) -> Tuple[List, np.ndarray]:
-        type_to_adj_list = [
-            [] for _ in range(self._num_fwd_edge_types + int(self.params["add_self_loop_edges"]))
-        ]  # type: List[List[Tuple[int, int]]]
-        type_to_num_incoming_edges = np.zeros(shape=(self.num_edge_types, num_nodes))
-        for raw_edge_type, edges in enumerate(raw_adjacency_lists):
-            if self.params["add_self_loop_edges"]:
-                fwd_edge_type = raw_edge_type + 1  # 0 will be the self-loop type
-            else:
-                fwd_edge_type = raw_edge_type  # Make edges start from 0
-            for src, dest in edges:
-                type_to_adj_list[fwd_edge_type].append((src, dest))
-                type_to_num_incoming_edges[fwd_edge_type, dest] += 1
-                if self.params["tie_fwd_bkwd_edges"]:
-                    type_to_adj_list[fwd_edge_type].append((dest, src))
-                    type_to_num_incoming_edges[fwd_edge_type, src] += 1
-
-        if self.params["add_self_loop_edges"]:
-            # Add self-loop edges (idx 0, which isn't used in the data):
-            for node in range(num_nodes):
-                type_to_num_incoming_edges[0, node] = 1
-                type_to_adj_list[0].append((node, node))
-
-        # Add backward edges as an additional edge type that goes backwards:
-        if not (self.params["tie_fwd_bkwd_edges"]):
-            # for (edge_type, adj_list) in enumerate(type_to_adj_list):
-            num_edge_types_in_adj_lists = len(type_to_adj_list)
-            for edge_type in range(num_edge_types_in_adj_lists):
-                adj_list = type_to_adj_list[edge_type]
-                # Don't add self loops again!
-                if edge_type == 0 and self.params["add_self_loop_edges"]:
-                    continue
-                bkwd_edge_type = len(type_to_adj_list)
-                type_to_adj_list.append([(y, x) for (x, y) in adj_list])
-                for (x, y) in adj_list:
-                    type_to_num_incoming_edges[bkwd_edge_type][y] += 1
-
-        # Convert the adjacency lists to numpy arrays.
-        type_to_adj_list = [
-            np.array(adj_list, dtype=np.int32)
-            if len(adj_list) > 0
-            else np.zeros(shape=(0, 2), dtype=np.int32)
-            for adj_list in type_to_adj_list
-        ]
-        return type_to_adj_list, type_to_num_incoming_edges
+    ) -> Tuple[List[np.ndarray], np.ndarray]:
+        return process_adjacency_lists(
+            adjacency_lists=raw_adjacency_lists,
+            num_nodes=num_nodes,
+            num_edge_types=self.num_edge_types,
+            add_self_loop_edges=self.params["add_self_loop_edges"],
+            tie_fwd_bkwd_edges=self.params["tie_fwd_bkwd_edges"],
+        )
 
     def _graph_iterator(self, data_fold: DataFold) -> Iterator[GraphSampleType]:
         if data_fold == DataFold.TRAIN:

--- a/tf2_gnn/data/jsonl_graph_dataset.py
+++ b/tf2_gnn/data/jsonl_graph_dataset.py
@@ -128,7 +128,6 @@ class JsonLGraphDataset(GraphDataset[GraphSampleType]):
         return process_adjacency_lists(
             adjacency_lists=raw_adjacency_lists,
             num_nodes=num_nodes,
-            num_edge_types=self.num_edge_types,
             add_self_loop_edges=self.params["add_self_loop_edges"],
             tie_fwd_bkwd_edges=self.params["tie_fwd_bkwd_edges"],
         )

--- a/tf2_gnn/data/ppi_dataset.py
+++ b/tf2_gnn/data/ppi_dataset.py
@@ -157,7 +157,6 @@ class PPIDataset(GraphDataset[PPIGraphSample]):
         return process_adjacency_lists(
             adjacency_lists=raw_adjacency_lists,
             num_nodes=num_nodes,
-            num_edge_types=self.num_edge_types,
             add_self_loop_edges=self.params["add_self_loop_edges"],
             tie_fwd_bkwd_edges=self.params["tie_fwd_bkwd_edges"],
         )

--- a/tf2_gnn/data/ppi_dataset.py
+++ b/tf2_gnn/data/ppi_dataset.py
@@ -104,9 +104,9 @@ class PPIDataset(GraphDataset[PPIGraphSample]):
         #  (1) Read features and labels. Implicitly, this gives us the number of nodes per graph.
         #  (2) Read all edges, and shift them so that each graph starts with node 0.
 
-        graph_id_to_edges: Dict[int, List] = {}
-        graph_id_to_features: Dict[int, List] = {}
-        graph_id_to_labels: Dict[int, List] = {}
+        graph_id_to_edges: Dict[int, List[Tuple[int, int]]] = {}
+        graph_id_to_features: Dict[int, List[np.ndarray]] = {}
+        graph_id_to_labels: Dict[int, List[np.ndarray]] = {}
         graph_id_to_node_offset: Dict[int, int] = {}
 
         num_total_nodes = node_to_features.shape[0]

--- a/tf2_gnn/data/ppi_dataset.py
+++ b/tf2_gnn/data/ppi_dataset.py
@@ -136,8 +136,11 @@ class PPIDataset(GraphDataset[PPIGraphSample]):
         for graph_id in graph_id_to_edges.keys():
             num_nodes = len(graph_id_to_features[graph_id])
 
-            adjacency_lists, type_to_node_to_num_inedges = self._process_raw_adjacency_lists(
-                raw_adjacency_lists=[graph_id_to_edges[graph_id]], num_nodes=num_nodes
+            adjacency_lists, type_to_node_to_num_inedges = process_adjacency_lists(
+                adjacency_lists=[graph_id_to_edges[graph_id]],
+                num_nodes=num_nodes,
+                add_self_loop_edges=self.params["add_self_loop_edges"],
+                tie_fwd_bkwd_edges=self.params["tie_fwd_bkwd_edges"],
             )
 
             final_graphs.append(
@@ -150,16 +153,6 @@ class PPIDataset(GraphDataset[PPIGraphSample]):
             )
 
         return final_graphs
-
-    def _process_raw_adjacency_lists(
-        self, raw_adjacency_lists: List[List[Tuple]], num_nodes: int
-    ) -> Tuple[List[np.ndarray], np.ndarray]:
-        return process_adjacency_lists(
-            adjacency_lists=raw_adjacency_lists,
-            num_nodes=num_nodes,
-            add_self_loop_edges=self.params["add_self_loop_edges"],
-            tie_fwd_bkwd_edges=self.params["tie_fwd_bkwd_edges"],
-        )
 
     # -------------------- Minibatching --------------------
     def get_batch_tf_data_description(self) -> GraphBatchTFDataDescription:

--- a/tf2_gnn/data/qm9_dataset.py
+++ b/tf2_gnn/data/qm9_dataset.py
@@ -10,6 +10,7 @@ import tensorflow as tf
 from dpu_utils.utils import RichPath
 
 from .graph_dataset import DataFold, GraphSample, GraphBatchTFDataDescription, GraphDataset
+from .utils import process_adjacency_lists
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,6 @@ class QM9Dataset(GraphDataset[QM9GraphSample]):
         self._node_feature_shape = None
         self._loaded_data: Dict[DataFold, List[QM9GraphSample]] = {}
         logger.debug("Done initialising QM9 dataset.")
-
 
     @property
     def num_edge_types(self) -> int:
@@ -130,49 +130,23 @@ class QM9Dataset(GraphDataset[QM9GraphSample]):
     def __graph_to_adjacency_lists(
         self, graph: Iterable[Tuple[int, int, int]], num_nodes: int
     ) -> Tuple[List[np.ndarray], np.ndarray]:
-        type_to_adj_list = [
-            [] for _ in range(self._num_fwd_edge_types + int(self.params["add_self_loop_edges"]))
-        ]  # type: List[List[Tuple[int, int]]]
-        type_to_num_incoming_edges = np.zeros(shape=(self.num_edge_types, num_nodes))
-        for src, e, dest in graph:
-            if self.params["add_self_loop_edges"]:
-                fwd_edge_type = e  # 0 will be the self-loop type
-            else:
-                fwd_edge_type = e - 1  # Make edges start from 0
-            type_to_adj_list[fwd_edge_type].append((src, dest))
-            type_to_num_incoming_edges[fwd_edge_type, dest] += 1
-            if self.params["tie_fwd_bkwd_edges"]:
-                type_to_adj_list[fwd_edge_type].append((dest, src))
-                type_to_num_incoming_edges[fwd_edge_type, src] += 1
+        raw_adjacency_lists = [[] for _ in range(self.num_edge_types)]
 
-        if self.params["add_self_loop_edges"]:
-            # Add self-loop edges (idx 0, which isn't used in the data):
-            for node in range(num_nodes):
-                type_to_num_incoming_edges[0, node] = 1
-                type_to_adj_list[0].append((node, node))
+        for src, edge_type, dest in graph:
+            raw_adjacency_lists[edge_type].append((src, dest))
 
-        # Add backward edges as an additional edge type that goes backwards:
-        if not (self.params["tie_fwd_bkwd_edges"]):
-            # for (edge_type, adj_list) in enumerate(type_to_adj_list):
-            num_edge_types_in_adj_lists = len(type_to_adj_list)
-            for edge_type in range(num_edge_types_in_adj_lists):
-                adj_list = type_to_adj_list[edge_type]
-                # Don't add self loops again!
-                if edge_type == 0 and self.params["add_self_loop_edges"]:
-                    continue
-                bkwd_edge_type = len(type_to_adj_list)
-                type_to_adj_list.append([(y, x) for (x, y) in adj_list])
-                for (x, y) in adj_list:
-                    type_to_num_incoming_edges[bkwd_edge_type][y] += 1
+        return self._process_raw_adjacency_lists(raw_adjacency_lists, num_nodes)
 
-        # Convert the adjacency lists to numpy arrays.
-        type_to_adj_list = [
-            np.array(adj_list, dtype=np.int32)
-            if len(adj_list) > 0
-            else np.zeros(shape=(0, 2), dtype=np.int32)
-            for adj_list in type_to_adj_list
-        ]
-        return type_to_adj_list, type_to_num_incoming_edges
+    def _process_raw_adjacency_lists(
+        self, raw_adjacency_lists: List[List[Tuple]], num_nodes: int
+    ) -> Tuple[List[np.ndarray], np.ndarray]:
+        return process_adjacency_lists(
+            adjacency_lists=raw_adjacency_lists,
+            num_nodes=num_nodes,
+            num_edge_types=self.num_edge_types,
+            add_self_loop_edges=self.params["add_self_loop_edges"],
+            tie_fwd_bkwd_edges=self.params["tie_fwd_bkwd_edges"],
+        )
 
     @property
     def node_feature_shape(self) -> Tuple:

--- a/tf2_gnn/data/qm9_dataset.py
+++ b/tf2_gnn/data/qm9_dataset.py
@@ -135,11 +135,6 @@ class QM9Dataset(GraphDataset[QM9GraphSample]):
         for src, edge_type, dest in graph:
             raw_adjacency_lists[edge_type].append((src, dest))
 
-        return self._process_raw_adjacency_lists(raw_adjacency_lists, num_nodes)
-
-    def _process_raw_adjacency_lists(
-        self, raw_adjacency_lists: List[List[Tuple]], num_nodes: int
-    ) -> Tuple[List[np.ndarray], np.ndarray]:
         return process_adjacency_lists(
             adjacency_lists=raw_adjacency_lists,
             num_nodes=num_nodes,

--- a/tf2_gnn/data/qm9_dataset.py
+++ b/tf2_gnn/data/qm9_dataset.py
@@ -143,7 +143,6 @@ class QM9Dataset(GraphDataset[QM9GraphSample]):
         return process_adjacency_lists(
             adjacency_lists=raw_adjacency_lists,
             num_nodes=num_nodes,
-            num_edge_types=self.num_edge_types,
             add_self_loop_edges=self.params["add_self_loop_edges"],
             tie_fwd_bkwd_edges=self.params["tie_fwd_bkwd_edges"],
         )

--- a/tf2_gnn/data/utils.py
+++ b/tf2_gnn/data/utils.py
@@ -9,7 +9,6 @@ Edge = Tuple[int, int]
 def process_adjacency_lists(
     adjacency_lists: List[List[Edge]],
     num_nodes: int,
-    num_edge_types: int,
     add_self_loop_edges: bool,
     tie_fwd_bkwd_edges: bool,
 ) -> Tuple[List[np.ndarray], np.ndarray]:
@@ -20,7 +19,7 @@ def process_adjacency_lists(
         adjacency_lists = _add_self_loop_edges(adjacency_lists, num_nodes)
 
     type_to_num_incoming_edges = _compute_type_to_num_inedges(
-        adjacency_lists=adjacency_lists, num_nodes=num_nodes, num_edge_types=num_edge_types
+        adjacency_lists=adjacency_lists, num_nodes=num_nodes
     )
 
     return _convert_adjacency_lists_to_numpy_arrays(adjacency_lists), type_to_num_incoming_edges
@@ -47,9 +46,8 @@ def _add_backward_edges(
         return adjacency_lists + flipped_adjacency_lists
 
 
-def _compute_type_to_num_inedges(
-    adjacency_lists: List[List[Edge]], num_nodes: int, num_edge_types: int
-) -> np.ndarray:
+def _compute_type_to_num_inedges(adjacency_lists: List[List[Edge]], num_nodes: int) -> np.ndarray:
+    num_edge_types = len(adjacency_lists)
     type_to_num_incoming_edges = np.zeros(shape=(num_edge_types, num_nodes))
 
     for edge_type, edges in enumerate(adjacency_lists):

--- a/tf2_gnn/data/utils.py
+++ b/tf2_gnn/data/utils.py
@@ -1,0 +1,68 @@
+from typing import List, Tuple
+
+import numpy as np
+
+
+Edge = Tuple[int, int]
+
+
+def process_adjacency_lists(
+    adjacency_lists: List[List[Edge]],
+    num_nodes: int,
+    num_edge_types: int,
+    add_self_loop_edges: bool,
+    tie_fwd_bkwd_edges: bool,
+) -> Tuple[List[np.ndarray], np.ndarray]:
+    adjacency_lists = _add_backward_edges(adjacency_lists, tie_fwd_bkwd_edges)
+
+    # Add self loops after adding backward edges to avoid adding loops twice.
+    if add_self_loop_edges:
+        adjacency_lists = _add_self_loop_edges(adjacency_lists, num_nodes)
+
+    type_to_num_incoming_edges = _compute_type_to_num_inedges(
+        adjacency_lists=adjacency_lists, num_nodes=num_nodes, num_edge_types=num_edge_types
+    )
+
+    return _convert_adjacency_lists_to_numpy_arrays(adjacency_lists), type_to_num_incoming_edges
+
+
+def _add_self_loop_edges(adjacency_lists: List[List[Edge]], num_nodes: int) -> List[List[Edge]]:
+    self_loops = [(i, i) for i in range(num_nodes)]
+    return [self_loops] + adjacency_lists
+
+
+def _add_backward_edges(
+    adjacency_lists: List[List[Edge]], tie_fwd_bkwd_edges: bool
+) -> List[List[Edge]]:
+    flipped_adjacency_lists = [
+        [(dest, src) for (src, dest) in adjacency_list] for adjacency_list in adjacency_lists
+    ]
+
+    if tie_fwd_bkwd_edges:
+        return [
+            adj + adj_flipped
+            for (adj, adj_flipped) in zip(adjacency_lists, flipped_adjacency_lists)
+        ]
+    else:
+        return adjacency_lists + flipped_adjacency_lists
+
+
+def _compute_type_to_num_inedges(
+    adjacency_lists: List[List[Edge]], num_nodes: int, num_edge_types: int
+) -> np.ndarray:
+    type_to_num_incoming_edges = np.zeros(shape=(num_edge_types, num_nodes))
+
+    for edge_type, edges in enumerate(adjacency_lists):
+        for _, dest in edges:
+            type_to_num_incoming_edges[edge_type, dest] += 1
+
+    return type_to_num_incoming_edges
+
+
+def _convert_adjacency_lists_to_numpy_arrays(adjacency_lists: List[List[Edge]]) -> List[np.ndarray]:
+    return [
+        np.array(adj_list, dtype=np.int32)
+        if len(adj_list) > 0
+        else np.zeros(shape=(0, 2), dtype=np.int32)
+        for adj_list in adjacency_lists
+    ]

--- a/tf2_gnn/test/data/test_datasets.py
+++ b/tf2_gnn/test/data/test_datasets.py
@@ -162,7 +162,7 @@ def ppi_test_case(tmp_data_dir, ppi_train_valid_paths):
             labels_key_name="node_labels",
             add_self_loop_edges=dataset_params["add_self_loop_edges"],
             tie_fwd_bkwd_edges=dataset_params["tie_fwd_bkwd_edges"],
-            self_loop_edge_type=1,
+            self_loop_edge_type=0,
         ),
     )
 

--- a/tf2_gnn/test/data/test_utils.py
+++ b/tf2_gnn/test/data/test_utils.py
@@ -1,0 +1,92 @@
+from typing import List, NamedTuple, Tuple
+
+import numpy as np
+import pytest
+from tf2_gnn.data.utils import process_adjacency_lists
+
+
+class TestInput(NamedTuple):
+    adjacency_lists: List[List[Tuple[int, int]]]
+    num_nodes: int
+    add_self_loop_edges: bool
+    tie_fwd_bkwd_edges: bool
+
+
+class TestOutput(NamedTuple):
+    adjacency_lists: List[np.ndarray]
+    type_to_num_incoming_edges: np.ndarray
+
+
+class TestCase(NamedTuple):
+    test_input: TestInput
+    expected_output: TestOutput
+
+
+def create_test_input(add_self_loop_edges: bool, tie_fwd_bkwd_edges: bool) -> TestInput:
+    return TestInput(
+        adjacency_lists=[[(0, 1), (1, 2)]],
+        num_nodes=3,
+        add_self_loop_edges=add_self_loop_edges,
+        tie_fwd_bkwd_edges=tie_fwd_bkwd_edges,
+    )
+
+
+def create_test_output(
+    adjacency_lists: List[List[Tuple[int, int]]], type_to_num_incoming_edges: List[List[int]]
+) -> TestOutput:
+    return TestOutput(
+        adjacency_lists=[np.array(adj_list, dtype=np.int32) for adj_list in adjacency_lists],
+        type_to_num_incoming_edges=np.array(type_to_num_incoming_edges),
+    )
+
+
+all_test_cases = [
+    TestCase(
+        test_input=create_test_input(add_self_loop_edges=False, tie_fwd_bkwd_edges=False),
+        expected_output=create_test_output(
+            adjacency_lists=[[(0, 1), (1, 2)], [(1, 0), (2, 1)]],
+            type_to_num_incoming_edges=[[0, 1, 1], [1, 1, 0]],
+        ),
+    ),
+    TestCase(
+        test_input=create_test_input(add_self_loop_edges=False, tie_fwd_bkwd_edges=True),
+        expected_output=create_test_output(
+            adjacency_lists=[[(0, 1), (1, 2), (1, 0), (2, 1)]],
+            type_to_num_incoming_edges=[[1, 2, 1]],
+        ),
+    ),
+    TestCase(
+        test_input=create_test_input(add_self_loop_edges=True, tie_fwd_bkwd_edges=False),
+        expected_output=create_test_output(
+            adjacency_lists=[[(0, 0), (1, 1), (2, 2)], [(0, 1), (1, 2)], [(1, 0), (2, 1)]],
+            type_to_num_incoming_edges=[[1, 1, 1], [0, 1, 1], [1, 1, 0]],
+        ),
+    ),
+    TestCase(
+        test_input=create_test_input(add_self_loop_edges=True, tie_fwd_bkwd_edges=True),
+        expected_output=create_test_output(
+            adjacency_lists=[[(0, 0), (1, 1), (2, 2)], [(0, 1), (1, 2), (1, 0), (2, 1)]],
+            type_to_num_incoming_edges=[[1, 1, 1], [1, 2, 1]],
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", all_test_cases)
+def test_process_adjacency_lists(test_case: TestCase):
+    inp = test_case.test_input
+    adjacency_lists, type_to_num_incoming_edges = process_adjacency_lists(
+        adjacency_lists=inp.adjacency_lists,
+        num_nodes=inp.num_nodes,
+        add_self_loop_edges=inp.add_self_loop_edges,
+        tie_fwd_bkwd_edges=inp.tie_fwd_bkwd_edges,
+    )
+
+    out = test_case.expected_output
+
+    assert len(adjacency_lists) == len(out.adjacency_lists)
+
+    for adj_got, adj_expected in zip(adjacency_lists, out.adjacency_lists):
+        assert np.array_equal(adj_got, adj_expected)
+
+    assert np.array_equal(type_to_num_incoming_edges, out.type_to_num_incoming_edges)


### PR DESCRIPTION
I unified how adjacency lists are processed (adding self loops, backward edges, computing `type_to_num_incoming_edges`) across all datasets (`JsonLGraphDataset`, `QM9Dataset`, `PPIDataset`). This refactoring _almost_ doesn't impact the behavior (the only difference is that self loops are now consistently added with edge type `0`, which was not the case previously for `PPIDataset`).

If we wish to further refactor this, it will now be _very_ easy to extract the handling of self loops and backward edges out of datasets, and into either the model or to `GraphDataset`.