### PR TITLE
Implement fine-grained control over tying forward-backward edge types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.2.2",
+    version="2.2.3",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.2.3",
+    version="2.3.0",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/data/jsonl_graph_dataset.py
+++ b/tf2_gnn/data/jsonl_graph_dataset.py
@@ -42,13 +42,13 @@ class JsonLGraphDataset(GraphDataset[GraphSampleType]):
         self._params = params
         self._num_fwd_edge_types = params["num_fwd_edge_types"]
 
-        self._params["tied_fwd_bkwd_edge_types"] = get_tied_edge_types(
+        self._tied_fwd_bkwd_edge_types = get_tied_edge_types(
             tie_fwd_bkwd_edges=params["tie_fwd_bkwd_edges"],
             num_fwd_edge_types=params["num_fwd_edge_types"],
         )
 
         self._num_edge_types = compute_number_of_edge_types(
-            tied_fwd_bkwd_edge_types=self.params["tied_fwd_bkwd_edge_types"],
+            tied_fwd_bkwd_edge_types=self._tied_fwd_bkwd_edge_types,
             num_fwd_edge_types=self._num_fwd_edge_types,
             add_self_loop_edges=params["add_self_loop_edges"],
         )
@@ -135,7 +135,7 @@ class JsonLGraphDataset(GraphDataset[GraphSampleType]):
             adjacency_lists=raw_adjacency_lists,
             num_nodes=num_nodes,
             add_self_loop_edges=self.params["add_self_loop_edges"],
-            tied_fwd_bkwd_edge_types=self.params["tied_fwd_bkwd_edge_types"],
+            tied_fwd_bkwd_edge_types=self._tied_fwd_bkwd_edge_types,
         )
 
     def _graph_iterator(self, data_fold: DataFold) -> Iterator[GraphSampleType]:

--- a/tf2_gnn/data/ppi_dataset.py
+++ b/tf2_gnn/data/ppi_dataset.py
@@ -43,12 +43,12 @@ class PPIDataset(GraphDataset[PPIGraphSample]):
     def __init__(self, params: Dict[str, Any], metadata: Optional[Dict[str, Any]] = None):
         super().__init__(params, metadata=metadata)
 
-        self._params["tied_fwd_bkwd_edge_types"] = get_tied_edge_types(
+        self._tied_fwd_bkwd_edge_types = get_tied_edge_types(
             tie_fwd_bkwd_edges=params["tie_fwd_bkwd_edges"], num_fwd_edge_types=1,
         )
 
         self._num_edge_types = compute_number_of_edge_types(
-            tied_fwd_bkwd_edge_types=self.params["tied_fwd_bkwd_edge_types"],
+            tied_fwd_bkwd_edge_types=self._tied_fwd_bkwd_edge_types,
             num_fwd_edge_types=1,
             add_self_loop_edges=params["add_self_loop_edges"],
         )
@@ -144,7 +144,7 @@ class PPIDataset(GraphDataset[PPIGraphSample]):
                 adjacency_lists=[graph_id_to_edges[graph_id]],
                 num_nodes=num_nodes,
                 add_self_loop_edges=self.params["add_self_loop_edges"],
-                tied_fwd_bkwd_edge_types=self.params["tied_fwd_bkwd_edge_types"],
+                tied_fwd_bkwd_edge_types=self._tied_fwd_bkwd_edge_types,
             )
 
             final_graphs.append(

--- a/tf2_gnn/data/qm9_dataset.py
+++ b/tf2_gnn/data/qm9_dataset.py
@@ -61,13 +61,13 @@ class QM9Dataset(GraphDataset[QM9GraphSample]):
         self._params = params
         self._num_fwd_edge_types = 4
 
-        self._params["tied_fwd_bkwd_edge_types"] = get_tied_edge_types(
+        self._tied_fwd_bkwd_edge_types = get_tied_edge_types(
             tie_fwd_bkwd_edges=params["tie_fwd_bkwd_edges"],
             num_fwd_edge_types=self._num_fwd_edge_types,
         )
 
         self._num_edge_types = compute_number_of_edge_types(
-            tied_fwd_bkwd_edge_types=self.params["tied_fwd_bkwd_edge_types"],
+            tied_fwd_bkwd_edge_types=self._tied_fwd_bkwd_edge_types,
             num_fwd_edge_types=self._num_fwd_edge_types,
             add_self_loop_edges=params["add_self_loop_edges"],
         )
@@ -145,7 +145,7 @@ class QM9Dataset(GraphDataset[QM9GraphSample]):
             adjacency_lists=raw_adjacency_lists,
             num_nodes=num_nodes,
             add_self_loop_edges=self.params["add_self_loop_edges"],
-            tied_fwd_bkwd_edge_types=self.params["tied_fwd_bkwd_edge_types"],
+            tied_fwd_bkwd_edge_types=self._tied_fwd_bkwd_edge_types,
         )
 
     @property

--- a/tf2_gnn/data/qm9_dataset.py
+++ b/tf2_gnn/data/qm9_dataset.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 from dpu_utils.utils import RichPath
 
 from .graph_dataset import DataFold, GraphSample, GraphBatchTFDataDescription, GraphDataset
-from .utils import process_adjacency_lists
+from .utils import compute_number_of_edge_types, get_tied_edge_types, process_adjacency_lists
 
 logger = logging.getLogger(__name__)
 
@@ -60,11 +60,17 @@ class QM9Dataset(GraphDataset[QM9GraphSample]):
         super().__init__(params, metadata=metadata)
         self._params = params
         self._num_fwd_edge_types = 4
-        if params["tie_fwd_bkwd_edges"]:
-            self._num_edge_types = self._num_fwd_edge_types
-        else:
-            self._num_edge_types = 2 * self._num_fwd_edge_types
-        self._num_edge_types += int(params["add_self_loop_edges"])
+
+        self._params["tied_fwd_bkwd_edge_types"] = get_tied_edge_types(
+            tie_fwd_bkwd_edges=params["tie_fwd_bkwd_edges"],
+            num_fwd_edge_types=self._num_fwd_edge_types,
+        )
+
+        self._num_edge_types = compute_number_of_edge_types(
+            tied_fwd_bkwd_edge_types=self.params["tied_fwd_bkwd_edge_types"],
+            num_fwd_edge_types=self._num_fwd_edge_types,
+            add_self_loop_edges=params["add_self_loop_edges"],
+        )
 
         self._node_feature_shape = None
         self._loaded_data: Dict[DataFold, List[QM9GraphSample]] = {}
@@ -139,7 +145,7 @@ class QM9Dataset(GraphDataset[QM9GraphSample]):
             adjacency_lists=raw_adjacency_lists,
             num_nodes=num_nodes,
             add_self_loop_edges=self.params["add_self_loop_edges"],
-            tie_fwd_bkwd_edges=self.params["tie_fwd_bkwd_edges"],
+            tied_fwd_bkwd_edge_types=self.params["tied_fwd_bkwd_edge_types"],
         )
 
     @property

--- a/tf2_gnn/data/utils.py
+++ b/tf2_gnn/data/utils.py
@@ -1,7 +1,6 @@
-from typing import List, Tuple
+from typing import List, Set, Tuple, Union
 
 import numpy as np
-
 
 Edge = Tuple[int, int]
 
@@ -10,9 +9,9 @@ def process_adjacency_lists(
     adjacency_lists: List[List[Edge]],
     num_nodes: int,
     add_self_loop_edges: bool,
-    tie_fwd_bkwd_edges: bool,
+    tied_fwd_bkwd_edge_types: Set[int],
 ) -> Tuple[List[np.ndarray], np.ndarray]:
-    adjacency_lists = _add_backward_edges(adjacency_lists, tie_fwd_bkwd_edges)
+    adjacency_lists = _add_backward_edges(adjacency_lists, tied_fwd_bkwd_edge_types)
 
     # Add self loops after adding backward edges to avoid adding loops twice.
     if add_self_loop_edges:
@@ -25,25 +24,44 @@ def process_adjacency_lists(
     return _convert_adjacency_lists_to_numpy_arrays(adjacency_lists), type_to_num_incoming_edges
 
 
+def get_tied_edge_types(
+    tie_fwd_bkwd_edges: Union[bool, Set[int]], num_fwd_edge_types: int
+) -> Set[int]:
+    if isinstance(tie_fwd_bkwd_edges, set):
+        return tie_fwd_bkwd_edges
+    elif tie_fwd_bkwd_edges:
+        return set(range(num_fwd_edge_types))
+    else:
+        return {}
+
+
+def compute_number_of_edge_types(
+    tied_fwd_bkwd_edge_types: Set[int], num_fwd_edge_types: int, add_self_loop_edges: bool
+) -> int:
+    """Computes the number of edge types after adding backward edges and possibly self loops."""
+    return 2 * num_fwd_edge_types - len(tied_fwd_bkwd_edge_types) + int(add_self_loop_edges)
+
+
 def _add_self_loop_edges(adjacency_lists: List[List[Edge]], num_nodes: int) -> List[List[Edge]]:
     self_loops = [(i, i) for i in range(num_nodes)]
     return [self_loops] + adjacency_lists
 
 
 def _add_backward_edges(
-    adjacency_lists: List[List[Edge]], tie_fwd_bkwd_edges: bool
+    adjacency_lists: List[List[Edge]], tied_fwd_bkwd_edge_types: Set[int]
 ) -> List[List[Edge]]:
-    flipped_adjacency_lists = [
-        [(dest, src) for (src, dest) in adjacency_list] for adjacency_list in adjacency_lists
-    ]
+    # Make sure the output will contain newly created lists.
+    new_adjacency_lists = [adj_list.copy() for adj_list in adjacency_lists]
 
-    if tie_fwd_bkwd_edges:
-        return [
-            adj + adj_flipped
-            for (adj, adj_flipped) in zip(adjacency_lists, flipped_adjacency_lists)
-        ]
-    else:
-        return adjacency_lists + flipped_adjacency_lists
+    for edge_type in range(len(adjacency_lists)):
+        flipped_adjacency_list = [(dest, src) for (src, dest) in adjacency_lists[edge_type]]
+
+        if edge_type in tied_fwd_bkwd_edge_types:
+            new_adjacency_lists[edge_type] += flipped_adjacency_list
+        else:
+            new_adjacency_lists.append(flipped_adjacency_list)
+
+    return new_adjacency_lists
 
 
 def _compute_type_to_num_inedges(adjacency_lists: List[List[Edge]], num_nodes: int) -> np.ndarray:

--- a/tf2_gnn/data/utils.py
+++ b/tf2_gnn/data/utils.py
@@ -11,6 +11,21 @@ def process_adjacency_lists(
     add_self_loop_edges: bool,
     tied_fwd_bkwd_edge_types: Set[int],
 ) -> Tuple[List[np.ndarray], np.ndarray]:
+    """Process adjacency lists by adding backward edges and self loops.
+
+    Args:
+        adjacency_lists: adjacency lists as a list of lists, with one list per edge type.
+        num_nodes: number of nodes in the graph.
+        add_self_loop_edges: whether to add self loops.
+        tied_fwd_bkwd_edge_types: For these forward edge types, the added backward edges will have
+            the same type as the forward edge. For all remaining forward edge types, the backward
+            edges will get a new fresh edge type.
+
+    Returns:
+        Processed adjacency lists (with backward edges and self loops added, and each inner list
+        converted to numpy array), and an array of shape [num_total_edge_types, num_nodes]
+        containing counts of edges of a given type adjacent to a given node.
+    """
     adjacency_lists = _add_backward_edges(adjacency_lists, tied_fwd_bkwd_edge_types)
 
     # Add self loops after adding backward edges to avoid adding loops twice.
@@ -27,6 +42,15 @@ def process_adjacency_lists(
 def get_tied_edge_types(
     tie_fwd_bkwd_edges: Union[bool, Set[int]], num_fwd_edge_types: int
 ) -> Set[int]:
+    """Get the forward edge types which should be tied with their respective backward edge types.
+
+    Args:
+        tie_fwd_bkwd_edges: either an explicit set of edge types to tie (in which case that set is
+            returned), or a bool value (whether to tie all edge types, or none).
+
+    Returns:
+        Set of forward edge types to tie, which can be passed to`process_adjacency_lists`.
+    """
     if isinstance(tie_fwd_bkwd_edges, set):
         return tie_fwd_bkwd_edges
     elif tie_fwd_bkwd_edges:


### PR DESCRIPTION
I made `tie_fwd_bkwd_edges` in all dataset classes accept arguments of type `Union[bool, Set[int]]`. It allows to either tie all forward/backward edge types (by supplying `bool`, as supported previously), or only a subset of them (by supplying a set of edge types to tie).

This is useful for downstream tasks which mix directed and undirected edges.