### PR TITLE
Fix the type of tie_fwd_bkwd_edges

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.3.0",
+    version="2.3.1",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/data/utils.py
+++ b/tf2_gnn/data/utils.py
@@ -40,19 +40,19 @@ def process_adjacency_lists(
 
 
 def get_tied_edge_types(
-    tie_fwd_bkwd_edges: Union[bool, Set[int]], num_fwd_edge_types: int
+    tie_fwd_bkwd_edges: Union[bool, List[int]], num_fwd_edge_types: int
 ) -> Set[int]:
     """Get the forward edge types which should be tied with their respective backward edge types.
 
     Args:
-        tie_fwd_bkwd_edges: either an explicit set of edge types to tie (in which case that set is
-            returned), or a bool value (whether to tie all edge types, or none).
+        tie_fwd_bkwd_edges: either an explicit list of edge types to tie (in which case that list is
+            returned as a set), or a bool value (whether to tie all edge types, or none).
 
     Returns:
         Set of forward edge types to tie, which can be passed to`process_adjacency_lists`.
     """
-    if isinstance(tie_fwd_bkwd_edges, set):
-        return tie_fwd_bkwd_edges
+    if isinstance(tie_fwd_bkwd_edges, list):
+        return set(tie_fwd_bkwd_edges)
     elif tie_fwd_bkwd_edges:
         return set(range(num_fwd_edge_types))
     else:

--- a/tf2_gnn/test/data/test_utils.py
+++ b/tf2_gnn/test/data/test_utils.py
@@ -9,7 +9,7 @@ class TestInput(NamedTuple):
     adjacency_lists: List[List[Tuple[int, int]]]
     num_nodes: int
     add_self_loop_edges: bool
-    tie_fwd_bkwd_edges: Union[bool, Set[int]]
+    tie_fwd_bkwd_edges: Union[bool, List[int]]
 
 
 class TestOutput(NamedTuple):
@@ -23,7 +23,7 @@ class TestCase(NamedTuple):
 
 
 def create_test_input(
-    add_self_loop_edges: bool, tie_fwd_bkwd_edges: Union[bool, Set[int]], two_edge_types=False
+    add_self_loop_edges: bool, tie_fwd_bkwd_edges: Union[bool, List[int]], two_edge_types=False
 ) -> TestInput:
     return TestInput(
         adjacency_lists=[[(0, 1)], [(1, 2)]] if two_edge_types else [[(0, 1), (1, 2)]],
@@ -73,7 +73,7 @@ all_test_cases = [
     ),
     TestCase(
         test_input=create_test_input(
-            add_self_loop_edges=False, tie_fwd_bkwd_edges={0}, two_edge_types=True
+            add_self_loop_edges=False, tie_fwd_bkwd_edges=[0], two_edge_types=True
         ),
         expected_output=create_test_output(
             adjacency_lists=[[(0, 1), (1, 0)], [(1, 2)], [(2, 1)]],
@@ -82,7 +82,7 @@ all_test_cases = [
     ),
     TestCase(
         test_input=create_test_input(
-            add_self_loop_edges=False, tie_fwd_bkwd_edges={1}, two_edge_types=True
+            add_self_loop_edges=False, tie_fwd_bkwd_edges=[1], two_edge_types=True
         ),
         expected_output=create_test_output(
             adjacency_lists=[[(0, 1)], [(1, 2), (2, 1)], [(1, 0)]],


### PR DESCRIPTION
The type of `tie_fwd_bkwd_edges` used to be `Union[bool, Set[int]]`, but JSON doesn't support sets, so this cannot be supplied on the command line, nor serialized into a JSON file. Hence, I change `Set` to `List`, and convert the parameter value into a set internally.