### PR TITLE
feat(WeightedSumGraphRepresentation): Allow clipping node reprs before summation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.3.1",
+    version="2.3.2",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/layers/nodes_to_graph_representation.py
+++ b/tf2_gnn/layers/nodes_to_graph_representation.py
@@ -174,8 +174,8 @@ class WeightedSumGraphRepresentation(NodesToGraphRepresentation):
                 raise ValueError()
 
         # (2) compute representations for each node/head pair:
-        node_reprs = self._transformation_mlp(
-            inputs.node_embeddings, training=training
+        node_reprs = self._transformation_mlp_activation_fun(
+            self._transformation_mlp(inputs.node_embeddings, training=training)
         )  # Shape [V, GD]
         node_reprs = tf.reshape(
             node_reprs,

--- a/tf2_gnn/layers/nodes_to_graph_representation.py
+++ b/tf2_gnn/layers/nodes_to_graph_representation.py
@@ -74,8 +74,8 @@ class WeightedSumGraphRepresentation(NodesToGraphRepresentation):
         transformation_mlp_layers: List[int] = [128],
         transformation_mlp_activation_fun: str = "ReLU",
         transformation_mlp_dropout_rate: float = 0.2,
-        transformation_mlp_result_lower_bound: Optional[int] = None,
-        transformation_mlp_result_upper_bound: Optional[int] = None,
+        transformation_mlp_result_lower_bound: Optional[float] = None,
+        transformation_mlp_result_upper_bound: Optional[float] = None,
         **kwargs,
     ):
         """
@@ -101,7 +101,7 @@ class WeightedSumGraphRepresentation(NodesToGraphRepresentation):
                 MLP will be clipped to before being scaled and summed up.
                 This is particularly useful to limit the magnitude of results when using "sigmoid"
                 or "none" as weighting function.
-            transformation_mlp_result_upper_bound: Lower bound that results of the transformation
+            transformation_mlp_result_upper_bound: Upper bound that results of the transformation
                 MLP will be clipped to before being scaled and summed up.
         """
         super().__init__(graph_representation_size, **kwargs)


### PR DESCRIPTION
This implements a new feature to clip values of the (transformed) node representations before summing them up. This is particularly important for using the layer using the (weighted) summation modes ("sigmoid", "none"), as those otherwise can lead to values of extremely large magnitudes. [I've noticed by trying them out in the MoLeRVAE setting.] Clipping before summation allows the layer to still perform tasks such as counting the number of nodes, which would be limited by clipping after summation.