### PR TITLE
Fix gradient clipping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.3.2",
+    version="2.4.0",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",


### PR DESCRIPTION
Existing implementation was not working (would have required a call to `optimizer.get_gradients`, which we never do). Re-implemented by hand now, and changed default to match the prior behaviour.