### PR TITLE
Make it possible to choose the edge type for self loops

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.5.0",
+    version="2.6.0",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/data/utils.py
+++ b/tf2_gnn/data/utils.py
@@ -100,7 +100,7 @@ def _add_backward_edges(
     adjacency_lists: List[List[Edge]], tied_fwd_bkwd_edge_types: Set[int]
 ) -> List[List[Edge]]:
     # Make sure the output will contain newly created lists.
-    new_adjacency_lists = [adj_list.copy() for adj_list in adjacency_lists]
+    new_adjacency_lists = deepcopy(adjacency_lists)
 
     for edge_type in range(len(adjacency_lists)):
         flipped_adjacency_list = [(dest, src) for (src, dest) in adjacency_lists[edge_type]]

--- a/tf2_gnn/data/utils.py
+++ b/tf2_gnn/data/utils.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import List, Set, Tuple, Union
 
 import numpy as np
@@ -10,6 +11,7 @@ def process_adjacency_lists(
     num_nodes: int,
     add_self_loop_edges: bool,
     tied_fwd_bkwd_edge_types: Set[int],
+    self_loop_edge_type: int = 0,
 ) -> Tuple[List[np.ndarray], np.ndarray]:
     """Process adjacency lists by adding backward edges and self loops.
 
@@ -20,6 +22,9 @@ def process_adjacency_lists(
         tied_fwd_bkwd_edge_types: For these forward edge types, the added backward edges will have
             the same type as the forward edge. For all remaining forward edge types, the backward
             edges will get a new fresh edge type.
+        self_loop_edge_type: edge type to use for the self loops. Also supports negative numbers:
+            for example, setting this to -1 will result in self loop edge type being the last one.
+            Only has effect if `add_self_loop_edges` is set.
 
     Returns:
         Processed adjacency lists (with backward edges and self loops added, and each inner list
@@ -30,7 +35,21 @@ def process_adjacency_lists(
 
     # Add self loops after adding backward edges to avoid adding loops twice.
     if add_self_loop_edges:
-        adjacency_lists = _add_self_loop_edges(adjacency_lists, num_nodes)
+        num_edge_types = len(adjacency_lists)
+
+        edge_type_lb = -(num_edge_types + 1)
+        edge_type_ub = num_edge_types
+
+        assert (
+            edge_type_lb <= self_loop_edge_type <= edge_type_ub
+        ), "Self loop edge type {} should be in range [{}, {}].".format(
+            self_loop_edge_type, edge_type_lb, edge_type_ub
+        )
+
+        if self_loop_edge_type < 0:
+            self_loop_edge_type += num_edge_types + 1
+
+        adjacency_lists = _add_self_loop_edges(adjacency_lists, num_nodes, self_loop_edge_type)
 
     type_to_num_incoming_edges = _compute_type_to_num_inedges(
         adjacency_lists=adjacency_lists, num_nodes=num_nodes
@@ -66,9 +85,15 @@ def compute_number_of_edge_types(
     return 2 * num_fwd_edge_types - len(tied_fwd_bkwd_edge_types) + int(add_self_loop_edges)
 
 
-def _add_self_loop_edges(adjacency_lists: List[List[Edge]], num_nodes: int) -> List[List[Edge]]:
+def _add_self_loop_edges(
+    adjacency_lists: List[List[Edge]], num_nodes: int, self_loop_edge_type: int = 0
+) -> List[List[Edge]]:
     self_loops = [(i, i) for i in range(num_nodes)]
-    return [self_loops] + adjacency_lists
+
+    adjacency_lists = deepcopy(adjacency_lists)
+    adjacency_lists.insert(self_loop_edge_type, self_loops)
+
+    return adjacency_lists
 
 
 def _add_backward_edges(

--- a/tf2_gnn/test/data/test_utils.py
+++ b/tf2_gnn/test/data/test_utils.py
@@ -10,6 +10,7 @@ class TestInput(NamedTuple):
     num_nodes: int
     add_self_loop_edges: bool
     tie_fwd_bkwd_edges: Union[bool, List[int]]
+    self_loop_edge_type: int
 
 
 class TestOutput(NamedTuple):
@@ -23,13 +24,17 @@ class TestCase(NamedTuple):
 
 
 def create_test_input(
-    add_self_loop_edges: bool, tie_fwd_bkwd_edges: Union[bool, List[int]], two_edge_types=False
+    add_self_loop_edges: bool,
+    tie_fwd_bkwd_edges: Union[bool, List[int]],
+    two_edge_types=False,
+    self_loop_edge_type=0,
 ) -> TestInput:
     return TestInput(
         adjacency_lists=[[(0, 1)], [(1, 2)]] if two_edge_types else [[(0, 1), (1, 2)]],
         num_nodes=3,
         add_self_loop_edges=add_self_loop_edges,
         tie_fwd_bkwd_edges=tie_fwd_bkwd_edges,
+        self_loop_edge_type=self_loop_edge_type,
     )
 
 
@@ -73,6 +78,24 @@ all_test_cases = [
     ),
     TestCase(
         test_input=create_test_input(
+            add_self_loop_edges=True, tie_fwd_bkwd_edges=False, self_loop_edge_type=-1
+        ),
+        expected_output=create_test_output(
+            adjacency_lists=[[(0, 1), (1, 2)], [(1, 0), (2, 1)], [(0, 0), (1, 1), (2, 2)]],
+            type_to_num_incoming_edges=[[0, 1, 1], [1, 1, 0], [1, 1, 1]],
+        ),
+    ),
+    TestCase(
+        test_input=create_test_input(
+            add_self_loop_edges=True, tie_fwd_bkwd_edges=True, self_loop_edge_type=-1
+        ),
+        expected_output=create_test_output(
+            adjacency_lists=[[(0, 1), (1, 2), (1, 0), (2, 1)], [(0, 0), (1, 1), (2, 2)]],
+            type_to_num_incoming_edges=[[1, 2, 1], [1, 1, 1]],
+        ),
+    ),
+    TestCase(
+        test_input=create_test_input(
             add_self_loop_edges=False, tie_fwd_bkwd_edges=[0], two_edge_types=True
         ),
         expected_output=create_test_output(
@@ -102,6 +125,7 @@ def test_process_adjacency_lists(test_case: TestCase):
         tied_fwd_bkwd_edge_types=get_tied_edge_types(
             tie_fwd_bkwd_edges=inp.tie_fwd_bkwd_edges, num_fwd_edge_types=len(inp.adjacency_lists)
         ),
+        self_loop_edge_type=inp.self_loop_edge_type,
     )
 
     out = test_case.expected_output


### PR DESCRIPTION
This PR slightly extends `process_adjacency_lists` to make it possible to choose the self loop edge type. This is useful for refactoring existing code that processes edges to use `process_adjacency_lists` instead (such a refactoring has to ensure edge types are not renumbered - otherwise this would be a breaking change).