### PR TITLE
Fixes microsoft/tf2-gnn#35

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We are [hiring](https://www.microsoft.com/en-us/research/theme/ada/#!opportuniti
 To test if all components are set up correctly, you can run a simple experiment on the
 protein-protein interaction (PPI) task first described by 
 [Zitnik & Leskovec, 2017](#zitnik-leskovec-2017).
-You can download the data for this task from https://s3.us-east-2.amazonaws.com/dgl.ai/dataset/ppi.zip
+You can download the data for this task from https://data.dgl.ai/dataset/ppi.zip
 and unzip it into a local directory (e.g., `data/ppi`).
 Then, you can use the convenience utility `tf2_gnn_train` (see `--help` for a description
 of options) to train a Relational Graph Convoluational Network model as follows:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and unzip it into a local directory (e.g., `data/ppi`).
 Then, you can use the convenience utility `tf2_gnn_train` (see `--help` for a description
 of options) to train a Relational Graph Convoluational Network model as follows:
 ```
-$ tf2_gnn_train RGCN PPI data/ppi/
+$ tf2_gnn_train RGCN PPI --max-epochs 10 data/ppi/
 Setting random seed 0.
 Trying to load task/model-specific default parameters from /dpuhome/files/users/mabrocks/Projects/TF2-GNN/tf2_gnn/cli_utils/default_hypers/PPI_RGCN.json ... File found.
  Dataset default parameters: {'max_nodes_per_batch': 10000, 'add_self_loop_edges': True, 'tie_fwd_bkwd_edges': False}


### PR DESCRIPTION
This is to fixes issue 35 that the link to download the test data is no longer available. 
This PR replace the invalid one with the one provided by @MarekPokropinski in the issue tracker.
And I tested the data from the new link works.

Changes:

-  replace the invalid link to download the test data with a valid one
-  update the command to do a test run, the update reduce the max epochs to just 10, the default one is too big for installation validation.




