### PR TITLE
fix(tf2_gnn/models/*): let __init__ pass extra kwargs to super()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.10.1",
+    version="2.11.0",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/models/graph_binary_classification_task.py
+++ b/tf2_gnn/models/graph_binary_classification_task.py
@@ -18,9 +18,6 @@ class GraphBinaryClassificationTask(GraphRegressionTask):
         super_params.update(these_hypers)
         return super_params
 
-    def __init__(self, params: Dict[str, Any], dataset: GraphDataset, name: str = None):
-        super().__init__(params, dataset=dataset, name=name)
-
     def compute_task_output(
         self,
         batch_features: Dict[str, tf.Tensor],

--- a/tf2_gnn/models/graph_regression_task.py
+++ b/tf2_gnn/models/graph_regression_task.py
@@ -30,8 +30,8 @@ class GraphRegressionTask(GraphTaskModel):
         super_params.update(these_hypers)
         return super_params
 
-    def __init__(self, params: Dict[str, Any], dataset: GraphDataset, name: str = None):
-        super().__init__(params, dataset=dataset, name=name)
+    def __init__(self, params: Dict[str, Any], dataset: GraphDataset, name: str = None, **kwargs):
+        super().__init__(params, dataset=dataset, name=name, **kwargs)
         self._node_to_graph_aggregation = None
 
         # Construct sublayers:

--- a/tf2_gnn/models/node_multiclass_task.py
+++ b/tf2_gnn/models/node_multiclass_task.py
@@ -31,8 +31,8 @@ class NodeMulticlassTask(GraphTaskModel):
         super_params.update(these_hypers)
         return super_params
 
-    def __init__(self, params: Dict[str, Any], dataset: GraphDataset, name: str = None):
-        super().__init__(params, dataset=dataset, name=name)
+    def __init__(self, params: Dict[str, Any], dataset: GraphDataset, name: str = None, **kwargs):
+        super().__init__(params, dataset=dataset, name=name, **kwargs)
         if not hasattr(dataset, "num_node_target_labels"):
             raise ValueError(f"Provided dataset of type {type(dataset)} does not provide num_node_target_labels information.")
         self._num_labels = dataset.num_node_target_labels

--- a/tf2_gnn/models/qm9_regression.py
+++ b/tf2_gnn/models/qm9_regression.py
@@ -40,8 +40,8 @@ class QM9RegressionTask(GraphTaskModel):
         super_params.update(these_hypers)
         return super_params
 
-    def __init__(self, params: Dict[str, Any], dataset: GraphDataset, name: str = None):
-        super().__init__(params, dataset=dataset, name=name)
+    def __init__(self, params: Dict[str, Any], dataset: GraphDataset, name: str = None, **kwargs):
+        super().__init__(params, dataset=dataset, name=name, **kwargs)
         assert isinstance(dataset, QM9Dataset)
 
         self._task_id = int(dataset._params["task_id"])


### PR DESCRIPTION
This fixes #39 by passing through the new `disable_tf_function_build` (and potentially any future new constructor args) to the super class.