### PR TITLE
Fix deprecation warning and update outdated info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Implementation and example training scripts of various flavours of graph neural 
 TensorFlow 2.0.
 Much of it is based on the code in the [tf-gnn-samples](https://github.com/microsoft/tf-gnn-samples) repo.
 
+The code is maintained by the [AI4Science team](https://www.microsoft.com/en-us/research/lab/microsoft-research-ai4science/)
+at Microsoft Research.
+We are [hiring](https://www.microsoft.com/en-us/research/lab/microsoft-research-ai4science/opportunities/?#).
+
+Currently this package is not under active developement, but it does continue to be used as a backend for [our generative model of molecules](https://github.com/microsoft/molecule-generation).
+
 ## Installation
 You can install the `tf2_gnn` module from the Python Package Index using 
 `pip install tf2_gnn`.
@@ -14,11 +20,6 @@ navigate to it and run `pip install -e ./` to install it as a local editable pac
 You will then be able to use the `tf2_gnn.layers.GNN` class and related utilities.
 
 This code was tested in Python 3.7, 3.8 and 3.9.
-
-The code is maintained by the [All Data AI](https://www.microsoft.com/en-us/research/group/ada/)
-group at Microsoft Research, Cambridge, UK.
-We are [hiring](https://www.microsoft.com/en-us/research/theme/ada/#!opportunities).
-
 
 ## Testing the Installation
 
@@ -205,10 +206,11 @@ used in tools such as `tf2_gnn_train`.
 
 # Authors
 
-* [Henry Jackson-Flux](mailto:Henry.JacksonFlux@microsoft.com)
-* [Marc Brockschmidt](mailto:Marc.Brockschmidt@microsoft.com)
-* [Megan Stanley](mailto:t-mestan@microsoft.com)
-* [Pashmina Cameron](mailto:Pashmina.Cameron@microsoft.com)
+* Henry Jackson-Flux
+* Marc Brockschmidt
+* [Megan Stanley](mailto:meganstanley@microsoft.com)
+* Pashmina Cameron
+* [Krzysztof Maziarz](mailto:krzysztof.maziarz@microsoft.com)
 
 
 # References

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ navigate to it and run `pip install -e ./` to install it as a local editable pac
 
 You will then be able to use the `tf2_gnn.layers.GNN` class and related utilities.
 
-This code was tested in Python 3.6 and 3.7 with TensorFlow 2.0 and 2.1.
+This code was tested in Python 3.7, 3.8 and 3.9.
 
 The code is maintained by the [All Data AI](https://www.microsoft.com/en-us/research/group/ada/)
 group at Microsoft Research, Cambridge, UK.

--- a/pipelines/azure-ci.yml
+++ b/pipelines/azure-ci.yml
@@ -17,12 +17,12 @@ jobs:
 
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
     maxParallel: 4
 
   steps:
@@ -54,8 +54,8 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.6'
-    displayName: 'Set python version to 3.6'
+      versionSpec: '3.7'
+    displayName: 'Set python version to 3.7'
 
   - task: ComponentGovernanceComponentDetection@0
     inputs:

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setuptools.setup(
         "tensorflow>=2.0.0",
         "dpu-utils>=0.2.7",
         "h5py",
+        "packaging",
     ],
     packages=setuptools.find_packages(where="."),
     package_dir={"": "."},

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="tf2_gnn",
-    version="2.13.0",
+    version="2.14.0",
     license="MIT",
     author="Marc Brockschmidt",
     author_email="mabrocks@microsoft.com",

--- a/tf2_gnn/cli_utils/training_utils.py
+++ b/tf2_gnn/cli_utils/training_utils.py
@@ -7,8 +7,14 @@ from typing import Dict, Optional, Callable, Any
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.training.tracking import data_structures as tf_data_structures
 from dpu_utils.utils import RichPath
+from packaging.version import parse as parse_version
+
+# Recent versions of `tensorflow` have moved the `data_structures` module.
+if parse_version(tf.__version__) >= parse_version("2.10"):
+    from tensorflow.python.trackable import data_structures as tf_data_structures
+else:
+    from tensorflow.python.training.tracking import data_structures as tf_data_structures
 
 from ..data import DataFold, GraphDataset
 from ..layers import get_known_message_passing_classes


### PR DESCRIPTION
In newest versions of tensorflow `tensorflow.python.training.tracking.data_structures` is being moved to `tensorflow.python.trackable.data_structures` (the move happens in `2.10` and currently there is a deprecation warning). In this PR, I fix this by patching up the corresponding import. Moreover, the `README.md` contained a bunch of outdated information, like the old team name (All Data AI) and several email addresses that no longer work, so I updated all that as well.